### PR TITLE
Add overlay over card artwork

### DIFF
--- a/css/draftsim.css
+++ b/css/draftsim.css
@@ -29,7 +29,8 @@ body
    max-width: 1620px;
    min-height: 632px;
    margin: auto;
-   display: block
+   display: block;
+   align: middle;
 }
 
 #pack_text_container
@@ -77,6 +78,46 @@ my_p {
   font-size: 24px;
   text-align: center;
   background: #FFFFFF;
+}
+
+.card_wrapper{
+  display: inline-block;
+  position: relative;
+}
+
+.card_img{
+  position: relative;
+  z-index: 1;
+  left: 0;
+  top: 0;
+
+}
+.card_overlay{
+  position: absolute; 
+  display: table;
+  z-index: 2;
+  top: 35px;
+  left: 18px;
+  right:0;
+  width: 187px;
+  height: 138px;
+  background-color: rgba(255,255,255,.70);
+  text-align: middle;
+  pointer-events: none; /*enables onclick to pass through overlay */
+}
+
+.card_rating_text{
+  text-align:center; 
+  vertical-align: middle;
+  display: table-cell;
+  font-size: 90px;
+  padding-bottom: 30px;
+  color: rgba(0,0,0,.75);
+  pointer-events: none; /*enables onclick to pass through text*/
+  }
+
+.nav li{
+  z-index: 99; /* ensures that the menu stays on top of all other page elements */
 }
 
 h1 {
@@ -358,6 +399,7 @@ b {
   padding 10px;
   display: inline-block;
   text-align: center;
+  clear: both;
 }
 
 .disclaimer{

--- a/draft.php
+++ b/draft.php
@@ -19,6 +19,7 @@
   ga('send', 'pageview');
 
 </script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"> //adds jQuery.js library to the page
 </head>
 <body>
 

--- a/draft.php
+++ b/draft.php
@@ -19,7 +19,7 @@
   ga('send', 'pageview');
 
 </script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"> //adds jQuery.js library to the page
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script> <!-- adds jQuery.js library to the page -->
 </head>
 <body>
 

--- a/drafting.js
+++ b/drafting.js
@@ -61,9 +61,11 @@
   if(display_element.style.display == 'none'){
     display_element.style.display = 'inline';
     display_element.style.minHeight= '200px';
+    $(".card_overlay").toggle();//jQuery call that shows overlays
   } else {
     display_element.style.display= 'none';
     display_element.style.minHeight= '0px';
+    $(".card_overlay").toggle(); //jQuery call that hides overlays
   }
 }
 
@@ -865,9 +867,40 @@ function Print_collection(){
 
    var card = draft.players[0].pack.pack_contents[i];
    var card_name = card.name.replace(/_/g, " ");
-   var extra_html = "<img src=" + card.image +  " alt=\"" + card_name + "\" title=\"" + card_name + "\" "+ "id=card_" + i + " onclick=make_pick(" + i + ") />";
+   
+   //Old 
+   //var extra_html = "<img src=" + card.image +  " alt=\"" + card_name + "\" title=\"" + card_name + "\" "+ "id=card_" + i + " onclick=make_pick(" + i + ") />";
+   //document.getElementById("pack_images").innerHTML = cur_html + extra_html;
 
-   document.getElementById("pack_images").innerHTML = cur_html + extra_html;
+   //New 
+   //the following creates a wrapper <div> around each item item in id=pack_images that contains the <img> as well as another <div> that is set to overlay the <img>
+   // each <img> and overlay <div> have "id="" created based on card name(since each card is unique in a pack) that allows them to be addressable for other functions.  
+   
+
+   //opens outer wrapper <div>. Named after the position in the array card_'i'
+   var c_wrapper_open = "<div id=\"card_" + i + "\" class=\"card_wrapper\">"; 
+  
+   //creates the <img>, assigns id=img_card-s_name. Note that single quote(') is converted to dash(-) in addition to spaces( ) being underscores(_). 
+   //This is to help mitigate interpreation issues when finding IDs. 
+   //these <img>s belong to the card_img CSS class
+   var c_image =  "<img src=" + card.image +  " alt=\"" + card_name + "\" title=\"" + card_name + "\" "+ "id=\"img_" + card.name.replace(/'/g,"-") + "\" class= \"card_img\" onclick= make_pick(" + i + ") />"; 
+
+   //creates the overlay <div>, assigns id=overlay_card-s_name. Note that single quote(') is converted to dash(-) in addition to spaces( ) being underscores(_). 
+   //This is to help mitigate interpreation issues when finding IDs.
+   //These <div>s belond to the card_overlay CSS class
+   var c_overlay = "<div id=\"overlay_" + card.name.replace(/'/g,"-") + "\" class=\"card_overlay\">" + "<p id=rating_" + card.name.replace(/'/g,"-") +" class=\"card_rating_text\">" + (parseFloat(card.myrating) + parseFloat(card.color_bias)).toFixed(1) + "</p>" + "</div>";
+    
+   //Closes the wrapper
+   var c_wrapper_close = "</div>";
+   
+   //write the wrapper <div>s, <img>s, and overlay <div>s to the page 
+   document.getElementById("pack_images").innerHTML = cur_html + c_wrapper_open + c_image + c_overlay + c_wrapper_close;
+   //document.getElementById("overlay_" + card.name.replace(/'/g,"-")).innerHTML = "<p id=rating_" + card.name.replace(/'/g,"-") +" class=\"card_rating_text\">" + (parseFloat(card.myrating) + parseFloat(card.color_bias)).toFixed(1) + "</p>";
+
+ }
+
+ if(document.getElementById('pack_text_container').style.display == 'none'){
+    $(".card_overlay").toggle(); //jQuery if suggestions are turned off this will hide the overlay
  }
 
  //Load next bot images when current ones are finished loading
@@ -941,6 +974,11 @@ var rows_2_show = Math.min(pack_length, 15); //no min
      cell3.innerHTML="0";
     }
    cell4.innerHTML =  (parseFloat(cur_card.myrating) + parseFloat(cur_card.color_bias)).toFixed(1);
+
+   //Writes color adjusted myrating into the card overlay <div> into a <p>, assigns id=rating_card-s_name. Note that single quote(') is converted to dash(-) in addition to spaces( ) being underscores(_). 
+   //This is to help mitigate interpreation issues when finding IDs. 
+   //these <p>s belong to the card_rating_text CSS class
+   
 
  }
   // var cur_html = document.getElementById("pack_images").innerHTML;


### PR DESCRIPTION
#### Summary
Encapsulate card ```<img>``` in a ```<div>``` and added another ```<div>``` over that to
be able to add text, outlines, or other visual changes.

The overlays are toggled on/off based on the existing suggestion
button.

#### Highlights
* Included ```jQuery.js``` to ```draft.php``` from google CDN to take advantage of ```toggle()``` function to easily show/hide elements and expand programmability of future code
* Wrapper ```<div>```s, card ```<img>```, overlay ```<div>```, and overlay ```<p>``` each have a ```id=``` now to make them findable with ```getElementById``` for future code
* Wrapper ```<div>```s, card ```<img>```, overlay ```<div>```, and overlay ```<p>``` tags each have their own CSS ```class=``` to make changes to the appearance easily and findable with ```getElementsByClass```
* Menu items now have CSS (```.nav li```) to set their ```z-index: 99;``` to be above the card overlays

#### Notes
* Any code that was functionally replaced was commented out and labeled ```//Old```
* All ```JS``` and ```jQuery``` added is commented with explanations of functionality

#### Disclaimer
My code is my best attempt at solving my idea of card overlays. This is my first experience with JS and CSS at this level of size and complexity. While the desired effect is achieved the CSS probably needs a good looking over to make sure it is the best way at defining the attributes, although I'm sure I tried every combination of attributes to get the flow to work correct.(CSS is the work of the devil)